### PR TITLE
Fix resending request when buffer is not yet parsed

### DIFF
--- a/python/ycm/buffer.py
+++ b/python/ycm/buffer.py
@@ -67,7 +67,7 @@ class Buffer( object ):
 
 
   def ShouldResendParseRequest( self ):
-    return self._parse_request.ShouldResend()
+    return bool( self._parse_request and self._parse_request.ShouldResend() )
 
 
   def UpdateDiagnostics( self, force=False ):

--- a/python/ycm/tests/youcompleteme_test.py
+++ b/python/ycm/tests/youcompleteme_test.py
@@ -1058,3 +1058,10 @@ def YouCompleteMe_OnCompleteDone_NoCompletionRequest_test( ycm,
                                                            on_complete_done ):
   ycm.OnCompleteDone()
   on_complete_done.assert_not_called()
+
+
+@YouCompleteMeInstance()
+def YouCompleteMe_ShouldResendFileParseRequest_NoParseRequest_test( ycm ):
+  current_buffer = VimBuffer( 'current_buffer' )
+  with MockVimBuffers( [ current_buffer ], current_buffer ):
+    assert_that( ycm.ShouldResendFileParseRequest(), equal_to( False ) )


### PR DESCRIPTION
# PR Prelude

Thank you for working on YCM! :)

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [ ] I have read and understood YCM's [CONTRIBUTING][cont] document.
- [ ] I have read and understood YCM's [CODE_OF_CONDUCT][code] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [ ] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[cont]: https://github.com/Valloric/YouCompleteMe/blob/master/CONTRIBUTING.md
[code]: https://github.com/Valloric/YouCompleteMe/blob/master/CODE_OF_CONDUCT.md
